### PR TITLE
feat: add title property to DAGs with validation

### DIFF
--- a/cmd/dag.go
+++ b/cmd/dag.go
@@ -32,7 +32,7 @@ var dagCmd = &cobra.Command{
 			log.Fatalf("error reading file '%s': %v", dagFile, err)
 		}
 
-		var dag = dag.NewDAG()
+		var dag = dag.NewDAG("Sample DAG")
 		err = dag.UnmarshalJSON(data)
 		if err != nil {
 			log.Fatalf("error unmarshalling file '%s': %v", dagFile, err)

--- a/cmd/interactive.go
+++ b/cmd/interactive.go
@@ -35,7 +35,7 @@ var interactiveCmd = &cobra.Command{
 			log.Fatalf("error reading file '%s': %v", interactiveDagFile, err)
 		}
 
-		var d = dag.NewDAG()
+		var d = dag.NewDAG("Interactive DAG")
 		err = d.UnmarshalJSON(data)
 		if err != nil {
 			log.Fatalf("error unmarshalling file '%s': %v", interactiveDagFile, err)

--- a/internal/adapter/http/dag_handler_test.go
+++ b/internal/adapter/http/dag_handler_test.go
@@ -110,7 +110,7 @@ func TestDAGHandler_List(t *testing.T) {
 }
 
 func TestDAGHandler_GetDAG(t *testing.T) {
-	testDAG := dag.NewDAG()
+	testDAG := dag.NewDAG("Test DAG")
 
 	tests := []struct {
 		name           string

--- a/internal/adapter/http/dag_presenter.go
+++ b/internal/adapter/http/dag_presenter.go
@@ -9,9 +9,10 @@ import (
 // DAGPresenter represents a complete Legal Case DAG structure for API responses
 //
 // @Description Legal Case DAG with questions, answers, and context
-// @Example {"id": "550e8400-e29b-41d4-a716-446655440000", "nodes": [{"id": "8b007ce4-b676-5fb3-9f93-f5f6c41cb655", "question": "Were you discriminated against?", "answers": [{"id": "fc28c4b6-d185-cf56-a7e4-dead499ff1e8", "answer": "Yes, age discrimination occurred", "user_context": "Manager explicitly mentioned my age", "metadata": {"confidence": 0.9, "tags": ["age_discrimination"]}}]}]}
+// @Example {"id": "550e8400-e29b-41d4-a716-446655440000", "title": "Employment Discrimination Case", "nodes": [{"id": "8b007ce4-b676-5fb3-9f93-f5f6c41cb655", "question": "Were you discriminated against?", "answers": [{"id": "fc28c4b6-d185-cf56-a7e4-dead499ff1e8", "answer": "Yes, age discrimination occurred", "user_context": "Manager explicitly mentioned my age", "metadata": {"confidence": 0.9, "tags": ["age_discrimination"]}}]}]}
 type DAGPresenter struct {
 	Id    uuid.UUID       `json:"id" example:"550e8400-e29b-41d4-a716-446655440000" description:"Unique identifier for the Legal Case DAG"`
+	Title string          `json:"title" example:"Employment Discrimination Case" description:"Human-readable title describing the legal case context"`
 	Nodes []NodePresenter `json:"nodes" description:"Array of question nodes that make up the legal case decision tree"`
 }
 
@@ -23,6 +24,7 @@ func NewDAGPresenter(dag *dag.DAG) DAGPresenter {
 
 	return DAGPresenter{
 		Id:    dag.Id,
+		Title: dag.Title,
 		Nodes: nodes,
 	}
 }
@@ -123,6 +125,7 @@ func (h *dagHandler) presenterToDAG(presenter DAGPresenter) *dag.DAG {
 
 	return &dag.DAG{
 		Id:    presenter.Id,
+		Title: presenter.Title,
 		Nodes: nodes,
 	}
 }

--- a/internal/dag/dag.go
+++ b/internal/dag/dag.go
@@ -10,6 +10,7 @@ import (
 
 type DAG struct {
 	Id    uuid.UUID `json:"id"`
+	Title string    `json:"title"`
 	Nodes map[uuid.UUID]Node
 }
 
@@ -28,9 +29,10 @@ type Answer struct {
 	Metadata    map[string]interface{} `json:"metadata,omitempty"`
 }
 
-func NewDAG() *DAG {
+func NewDAG(title string) *DAG {
 	return &DAG{
 		Id:    uuid.New(),
+		Title: title,
 		Nodes: make(map[uuid.UUID]Node),
 	}
 }
@@ -79,6 +81,7 @@ func (d DAG) GetRootNode() (Node, error) {
 // dagJSON represents the JSON structure for marshaling/unmarshaling a DAG
 type dagJSON struct {
 	Id    uuid.UUID `json:"id"`
+	Title string    `json:"title"`
 	Nodes []Node    `json:"nodes"`
 }
 
@@ -88,9 +91,10 @@ func (d DAG) MarshalJSON() ([]byte, error) {
 		nodes = append(nodes, node)
 	}
 
-	// Create a dagJSON struct to marshal both id and nodes
+	// Create a dagJSON struct to marshal both id, title and nodes
 	dag := dagJSON{
 		Id:    d.Id,
+		Title: d.Title,
 		Nodes: nodes,
 	}
 
@@ -105,8 +109,9 @@ func (d *DAG) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("error unmarshalling DAG data: %w", err)
 	}
 
-	// Set the DAG id from the unmarshaled data
+	// Set the DAG id and title from the unmarshaled data
 	d.Id = dag.Id
+	d.Title = dag.Title
 
 	// Initialize the Nodes map if it's nil
 	if d.Nodes == nil {

--- a/internal/dag/dag_test.go
+++ b/internal/dag/dag_test.go
@@ -14,9 +14,11 @@ func TestNewDAG(t *testing.T) {
 	t.Run("creates empty DAG with initialized fields", func(t *testing.T) {
 		t.Parallel()
 
-		d := NewDAG()
+		title := "Test DAG"
+		d := NewDAG(title)
 
 		assert.NotEqual(t, uuid.Nil, d.Id)
+		assert.Equal(t, title, d.Title)
 		assert.NotNil(t, d.Nodes)
 		assert.Equal(t, 0, len(d.Nodes))
 	})
@@ -25,7 +27,7 @@ func TestNewDAG(t *testing.T) {
 func TestDAG_GetNode(t *testing.T) {
 	t.Parallel()
 
-	d := NewDAG()
+	d := NewDAG("Test DAG")
 	testId1 := uuid.New()
 	testId2 := uuid.New()
 
@@ -98,7 +100,7 @@ func TestDAG_GetRootNode(t *testing.T) {
 		{
 			name: "finds single root node",
 			setup: func() *DAG {
-				d := NewDAG()
+				d := NewDAG("Test DAG")
 				rootId := uuid.New()
 				childId := uuid.New()
 
@@ -128,7 +130,7 @@ func TestDAG_GetRootNode(t *testing.T) {
 		{
 			name: "returns error for empty DAG",
 			setup: func() *DAG {
-				return NewDAG()
+				return NewDAG("Test DAG")
 			},
 			wantErr: true,
 			errMsg:  "no root node found",
@@ -136,7 +138,7 @@ func TestDAG_GetRootNode(t *testing.T) {
 		{
 			name: "returns error when no root node found",
 			setup: func() *DAG {
-				d := NewDAG()
+				d := NewDAG("Test DAG")
 				node1Id := uuid.New()
 				node2Id := uuid.New()
 
@@ -175,7 +177,7 @@ func TestDAG_GetRootNode(t *testing.T) {
 		{
 			name: "returns error when multiple root nodes found",
 			setup: func() *DAG {
-				d := NewDAG()
+				d := NewDAG("Test DAG")
 				root1Id := uuid.New()
 				root2Id := uuid.New()
 
@@ -230,7 +232,7 @@ func TestDAG_MarshalJSON(t *testing.T) {
 		{
 			name: "marshals empty DAG",
 			setup: func() *DAG {
-				return NewDAG()
+				return NewDAG("Test DAG")
 			},
 			verify: func(t *testing.T, data []byte) {
 				assert.Contains(t, string(data), `"nodes":[]`)
@@ -240,7 +242,7 @@ func TestDAG_MarshalJSON(t *testing.T) {
 		{
 			name: "marshals DAG with single node",
 			setup: func() *DAG {
-				d := NewDAG()
+				d := NewDAG("Test DAG")
 				nodeId := uuid.New()
 				answerId := uuid.New()
 
@@ -269,7 +271,7 @@ func TestDAG_MarshalJSON(t *testing.T) {
 		{
 			name: "marshals DAG with multiple nodes",
 			setup: func() *DAG {
-				d := NewDAG()
+				d := NewDAG("Test DAG")
 				node1Id := uuid.New()
 				node2Id := uuid.New()
 
@@ -395,7 +397,7 @@ func TestDAG_UnmarshalJSON(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			d := NewDAG()
+			d := NewDAG("Test DAG")
 			err := d.UnmarshalJSON([]byte(tt.data))
 
 			if tt.wantErr {
@@ -423,7 +425,7 @@ func TestDAG_String(t *testing.T) {
 		{
 			name: "formats empty DAG",
 			setup: func() *DAG {
-				return NewDAG()
+				return NewDAG("Test DAG")
 			},
 			verify: func(t *testing.T, result string) {
 				assert.Equal(t, "", result)
@@ -432,7 +434,7 @@ func TestDAG_String(t *testing.T) {
 		{
 			name: "formats DAG with nodes and answers",
 			setup: func() *DAG {
-				d := NewDAG()
+				d := NewDAG("Test DAG")
 				nodeId := uuid.New()
 
 				node := Node{
@@ -492,7 +494,7 @@ func TestDAG_Walk(t *testing.T) {
 		{
 			name: "walks through simple path",
 			setup: func() (*DAG, uuid.UUID) {
-				d := NewDAG()
+				d := NewDAG("Test DAG")
 				rootId := uuid.New()
 				childId := uuid.New()
 				answerId1 := uuid.New()
@@ -545,7 +547,7 @@ func TestDAG_Walk(t *testing.T) {
 		{
 			name: "stops at leaf node",
 			setup: func() (*DAG, uuid.UUID) {
-				d := NewDAG()
+				d := NewDAG("Test DAG")
 				rootId := uuid.New()
 
 				root := Node{
@@ -565,7 +567,7 @@ func TestDAG_Walk(t *testing.T) {
 		{
 			name: "returns error for invalid node",
 			setup: func() (*DAG, uuid.UUID) {
-				return NewDAG(), uuid.New()
+				return NewDAG("Test DAG"), uuid.New()
 			},
 			fnAnswer: func(node Node) (Answer, error) {
 				return Answer{}, nil
@@ -576,7 +578,7 @@ func TestDAG_Walk(t *testing.T) {
 		{
 			name: "returns error when fnAnswer fails",
 			setup: func() (*DAG, uuid.UUID) {
-				d := NewDAG()
+				d := NewDAG("Test DAG")
 				rootId := uuid.New()
 
 				root := Node{
@@ -603,7 +605,7 @@ func TestDAG_Walk(t *testing.T) {
 		{
 			name: "returns error for invalid answer",
 			setup: func() (*DAG, uuid.UUID) {
-				d := NewDAG()
+				d := NewDAG("Test DAG")
 				rootId := uuid.New()
 
 				root := Node{
@@ -654,7 +656,7 @@ func TestDAG_WalkParentNodePointers(t *testing.T) {
 	t.Parallel()
 
 	// Create a DAG
-	d := NewDAG()
+	d := NewDAG("Test DAG")
 	node1Id := uuid.New()
 	node2Id := uuid.New()
 	answer1Id := uuid.New()
@@ -689,7 +691,7 @@ func TestDAG_WalkParentNodePointers(t *testing.T) {
 	jsonData, err := d.MarshalJSON()
 	require.NoError(t, err)
 
-	testDAG := NewDAG()
+	testDAG := NewDAG("Test DAG")
 	err = testDAG.UnmarshalJSON(jsonData)
 	require.NoError(t, err)
 
@@ -725,7 +727,7 @@ func TestDAG_JSONRoundTrip(t *testing.T) {
 		t.Parallel()
 
 		// Setup original DAG
-		original := NewDAG()
+		original := NewDAG("Test DAG")
 		nodeId := uuid.New()
 		answerId := uuid.New()
 
@@ -748,7 +750,7 @@ func TestDAG_JSONRoundTrip(t *testing.T) {
 		require.NoError(t, err)
 
 		// Unmarshal
-		roundtrip := NewDAG()
+		roundtrip := NewDAG("Test DAG")
 		err = roundtrip.UnmarshalJSON(data)
 		require.NoError(t, err)
 
@@ -777,7 +779,7 @@ func TestDAG_ContextMarshalling(t *testing.T) {
 		t.Parallel()
 
 		// Create DAG with context-rich answers
-		d := NewDAG()
+		d := NewDAG("Test DAG")
 		nodeId := uuid.New()
 		answerId := uuid.New()
 
@@ -849,7 +851,7 @@ func TestDAG_ContextMarshalling(t *testing.T) {
 			]
 		}`
 
-		d := NewDAG()
+		d := NewDAG("Test DAG")
 		err := d.UnmarshalJSON([]byte(jsonData))
 		require.NoError(t, err)
 
@@ -886,7 +888,7 @@ func TestDAG_ContextMarshalling(t *testing.T) {
 		t.Parallel()
 
 		// Create DAG with answers that have no context
-		d := NewDAG()
+		d := NewDAG("Test DAG")
 		nodeId := uuid.New()
 
 		answer := Answer{
@@ -923,7 +925,7 @@ func TestDAG_ContextMarshalling(t *testing.T) {
 		t.Parallel()
 
 		// Create DAG with mixed answer types
-		d := NewDAG()
+		d := NewDAG("Test DAG")
 		nodeId := uuid.New()
 		answer1Id := uuid.New()
 		answer2Id := uuid.New()
@@ -959,7 +961,7 @@ func TestDAG_ContextMarshalling(t *testing.T) {
 		jsonData, err := d.MarshalJSON()
 		require.NoError(t, err)
 
-		newDAG := NewDAG()
+		newDAG := NewDAG("Test DAG")
 		err = newDAG.UnmarshalJSON(jsonData)
 		require.NoError(t, err)
 

--- a/internal/port/file_dag_repository.go
+++ b/internal/port/file_dag_repository.go
@@ -35,7 +35,7 @@ func (r *FileDAGRepository) Get(ctx context.Context, id uuid.UUID) (*dag.DAG, er
 		)
 	}
 
-	var dag = dag.NewDAG()
+	var dag = dag.NewDAG("Untitled DAG")
 	err = dag.UnmarshalJSON(data)
 	if err != nil {
 		return nil, fmt.Errorf(

--- a/internal/port/file_dag_repository_test.go
+++ b/internal/port/file_dag_repository_test.go
@@ -36,7 +36,7 @@ func TestFileDAGRepository_CreateAndGet(t *testing.T) {
 			name: "successfully create and retrieve DAG",
 			setup: func() (*FileDAGRepository, *dag.DAG) {
 				repo := NewFileDAGRepository(tempDir)
-				testDAG := dag.NewDAG()
+				testDAG := dag.NewDAG("Test DAG")
 				return repo, testDAG
 			},
 			wantErr: false,
@@ -93,7 +93,7 @@ func TestFileDAGRepository_Create_AlreadyExists(t *testing.T) {
 
 	repo := NewFileDAGRepository(tempDir)
 	ctx := context.Background()
-	testDAG := dag.NewDAG()
+	testDAG := dag.NewDAG("Test DAG")
 
 	// Create the DAG first time
 	err = repo.Create(ctx, testDAG)
@@ -151,7 +151,7 @@ func TestFileDAGRepository_Delete(t *testing.T) {
 
 	repo := NewFileDAGRepository(tempDir)
 	ctx := context.Background()
-	testDAG := dag.NewDAG()
+	testDAG := dag.NewDAG("Test DAG")
 
 	// Create a DAG first
 	err = repo.Create(ctx, testDAG)
@@ -205,8 +205,8 @@ func TestFileDAGRepository_List(t *testing.T) {
 	assert.Len(t, ids, 0)
 
 	// Add some DAGs
-	dag1 := dag.NewDAG()
-	dag2 := dag.NewDAG()
+	dag1 := dag.NewDAG("Test DAG")
+	dag2 := dag.NewDAG("Test DAG")
 
 	err = repo.Create(ctx, dag1)
 	require.NoError(t, err)
@@ -231,7 +231,7 @@ func TestFileDAGRepository_List_WithInvalidFiles(t *testing.T) {
 	ctx := context.Background()
 
 	// Create some valid DAG files
-	validDAG := dag.NewDAG()
+	validDAG := dag.NewDAG("Test DAG")
 	err = repo.Create(ctx, validDAG)
 	require.NoError(t, err)
 
@@ -279,7 +279,7 @@ func TestFileDAGRepository_Update(t *testing.T) {
 
 	repo := NewFileDAGRepository(tempDir)
 	ctx := context.Background()
-	testDAG := dag.NewDAG()
+	testDAG := dag.NewDAG("Test DAG")
 
 	// Create a DAG first
 	err = repo.Create(ctx, testDAG)
@@ -344,7 +344,7 @@ func TestFileDAGRepository_Update_FunctionFails(t *testing.T) {
 
 	repo := NewFileDAGRepository(tempDir)
 	ctx := context.Background()
-	testDAG := dag.NewDAG()
+	testDAG := dag.NewDAG("Test DAG")
 
 	// Create a DAG
 	err = repo.Create(ctx, testDAG)
@@ -368,7 +368,7 @@ func TestFileDAGRepository_Update_IDChange(t *testing.T) {
 
 	repo := NewFileDAGRepository(tempDir)
 	ctx := context.Background()
-	testDAG := dag.NewDAG()
+	testDAG := dag.NewDAG("Test DAG")
 
 	// Create a DAG
 	err = repo.Create(ctx, testDAG)
@@ -395,7 +395,7 @@ func TestFileDAGRepository_CreateDirectoryIfNotExists(t *testing.T) {
 	nestedDir := filepath.Join(tempBase, "nested", "directory", "structure")
 	repo := NewFileDAGRepository(nestedDir)
 	ctx := context.Background()
-	testDAG := dag.NewDAG()
+	testDAG := dag.NewDAG("Test DAG")
 
 	// Create should create the directory structure
 	err = repo.Create(ctx, testDAG)
@@ -419,7 +419,7 @@ func TestFileDAGRepository_DAGWithComplexStructure(t *testing.T) {
 	ctx := context.Background()
 
 	// Create a complex DAG with nodes and answers
-	testDAG := dag.NewDAG()
+	testDAG := dag.NewDAG("Test DAG")
 
 	// Root node
 	rootNode := dag.Node{
@@ -508,7 +508,7 @@ func TestFileDAGRepository_RoundTripConsistency(t *testing.T) {
 
 	repo := NewFileDAGRepository(tempDir)
 	ctx := context.Background()
-	originalDAG := dag.NewDAG()
+	originalDAG := dag.NewDAG("Test DAG")
 
 	// Add a complex node structure
 	node := dag.Node{
@@ -597,7 +597,7 @@ func TestFileDAGRepository_ErrorHandling_FilePermissions(t *testing.T) {
 
 	repo := NewFileDAGRepository(tempDir)
 	ctx := context.Background()
-	testDAG := dag.NewDAG()
+	testDAG := dag.NewDAG("Test DAG")
 
 	// Create should fail due to permission issues
 	err = repo.Create(ctx, testDAG)

--- a/internal/port/in_memory_dag_repository_test.go
+++ b/internal/port/in_memory_dag_repository_test.go
@@ -30,7 +30,7 @@ func TestInMemoryDAGRepository_CreateAndGet(t *testing.T) {
 			name: "successfully create and retrieve DAG",
 			setup: func() (*InMemoryDAGRepository, *dag.DAG) {
 				repo := NewInMemoryDAGRepository()
-				testDAG := dag.NewDAG()
+				testDAG := dag.NewDAG("Test DAG")
 				return repo, testDAG
 			},
 			wantErr: false,
@@ -89,7 +89,7 @@ func TestInMemoryDAGRepository_Get_NotFound(t *testing.T) {
 func TestInMemoryDAGRepository_Delete(t *testing.T) {
 	repo := NewInMemoryDAGRepository()
 	ctx := context.Background()
-	testDAG := dag.NewDAG()
+	testDAG := dag.NewDAG("Test DAG")
 
 	// Create a DAG first
 	err := repo.Create(ctx, testDAG)
@@ -129,8 +129,8 @@ func TestInMemoryDAGRepository_List(t *testing.T) {
 	assert.Len(t, ids, 0)
 
 	// Add some DAGs
-	dag1 := dag.NewDAG()
-	dag2 := dag.NewDAG()
+	dag1 := dag.NewDAG("Test DAG")
+	dag2 := dag.NewDAG("Test DAG")
 
 	err = repo.Create(ctx, dag1)
 	require.NoError(t, err)
@@ -148,7 +148,7 @@ func TestInMemoryDAGRepository_List(t *testing.T) {
 func TestInMemoryDAGRepository_Update(t *testing.T) {
 	repo := NewInMemoryDAGRepository()
 	ctx := context.Background()
-	testDAG := dag.NewDAG()
+	testDAG := dag.NewDAG("Test DAG")
 
 	// Create a DAG first
 	err := repo.Create(ctx, testDAG)
@@ -203,7 +203,7 @@ func TestInMemoryDAGRepository_Update_NotFound(t *testing.T) {
 func TestInMemoryDAGRepository_Update_FunctionFails(t *testing.T) {
 	repo := NewInMemoryDAGRepository()
 	ctx := context.Background()
-	testDAG := dag.NewDAG()
+	testDAG := dag.NewDAG("Test DAG")
 
 	// Create a DAG
 	err := repo.Create(ctx, testDAG)
@@ -222,7 +222,7 @@ func TestInMemoryDAGRepository_Update_FunctionFails(t *testing.T) {
 func TestInMemoryDAGRepository_Update_IDChange(t *testing.T) {
 	repo := NewInMemoryDAGRepository()
 	ctx := context.Background()
-	testDAG := dag.NewDAG()
+	testDAG := dag.NewDAG("Test DAG")
 
 	// Create a DAG
 	err := repo.Create(ctx, testDAG)
@@ -251,7 +251,7 @@ func TestInMemoryDAGRepository_ConcurrentAccess(t *testing.T) {
 	for i := 0; i < numGoroutines; i++ {
 		go func() {
 			for j := 0; j < numDAGsPerGoroutine; j++ {
-				testDAG := dag.NewDAG()
+				testDAG := dag.NewDAG("Test DAG")
 				err := repo.Create(ctx, testDAG)
 				assert.NoError(t, err)
 

--- a/internal/usecase/get_dag_test.go
+++ b/internal/usecase/get_dag_test.go
@@ -26,7 +26,7 @@ func TestNewGetDAGUseCase(t *testing.T) {
 }
 
 func TestGetDAGUseCase_Execute(t *testing.T) {
-	testDAG := dag.NewDAG()
+	testDAG := dag.NewDAG("Test DAG")
 	validUUID := testDAG.Id.String()
 
 	tests := []struct {
@@ -110,7 +110,7 @@ func TestGetDAGUseCase_Execute(t *testing.T) {
 			},
 			setupMock: func(mockRepo *mocks.MockDAGRepository) {
 				expectedUUID := uuid.MustParse("550e8400-e29b-41d4-a716-446655440000")
-				retrievedDAG := dag.NewDAG()
+				retrievedDAG := dag.NewDAG("Test DAG")
 				retrievedDAG.Id = expectedUUID
 				mockRepo.EXPECT().Get(gomock.Any(), expectedUUID).Return(retrievedDAG, nil)
 			},
@@ -165,7 +165,7 @@ func TestGetDAGUseCase_Execute_ValidationEdgeCases(t *testing.T) {
 			},
 			setupMock: func(mockRepo *mocks.MockDAGRepository) {
 				expectedUUID := uuid.MustParse("550e8400-e29b-41d4-a716-446655440000")
-				testDAG := dag.NewDAG()
+				testDAG := dag.NewDAG("Test DAG")
 				testDAG.Id = expectedUUID
 				mockRepo.EXPECT().Get(gomock.Any(), expectedUUID).Return(testDAG, nil)
 			},
@@ -220,7 +220,7 @@ func TestGetDAGUseCase_Execute_ContextPropagation(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
-	testDAG := dag.NewDAG()
+	testDAG := dag.NewDAG("Test DAG")
 	mockRepo := mocks.NewMockDAGRepository(ctrl)
 
 	// Verify that context is properly passed to repository
@@ -241,7 +241,7 @@ func TestGetDAGUseCase_Execute_RepositoryErrorWrapping(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
-	testDAG := dag.NewDAG()
+	testDAG := dag.NewDAG("Test DAG")
 	mockRepo := mocks.NewMockDAGRepository(ctrl)
 
 	// Test that repository errors are properly propagated

--- a/internal/usecase/update_dag.go
+++ b/internal/usecase/update_dag.go
@@ -79,6 +79,10 @@ func (u *UpdateDAGUseCase) validateDAGStructure(d *dag.DAG) error {
 		return fmt.Errorf("DAG ID cannot be empty")
 	}
 
+	if d.Title == "" {
+		return fmt.Errorf("DAG title cannot be empty")
+	}
+
 	// Validate nodes
 	if len(d.Nodes) == 0 {
 		return fmt.Errorf("DAG must contain at least one node")

--- a/internal/usecase/update_dag_test.go
+++ b/internal/usecase/update_dag_test.go
@@ -185,15 +185,27 @@ func TestUpdateDAGUseCase_ValidateDAGStructure(t *testing.T) {
 			name: "validates empty DAG ID",
 			dag: &dag.DAG{
 				Id:    uuid.Nil,
+				Title: "Valid Title",
 				Nodes: map[uuid.UUID]dag.Node{},
 			},
 			wantError: true,
 			errorMsg:  "DAG ID cannot be empty",
 		},
 		{
+			name: "validates empty title",
+			dag: &dag.DAG{
+				Id:    uuid.New(),
+				Title: "",
+				Nodes: map[uuid.UUID]dag.Node{},
+			},
+			wantError: true,
+			errorMsg:  "DAG title cannot be empty",
+		},
+		{
 			name: "validates empty nodes",
 			dag: &dag.DAG{
 				Id:    uuid.New(),
+				Title: "Valid Title",
 				Nodes: map[uuid.UUID]dag.Node{},
 			},
 			wantError: true,
@@ -204,7 +216,8 @@ func TestUpdateDAGUseCase_ValidateDAGStructure(t *testing.T) {
 			dag: func() *dag.DAG {
 				nodeId := uuid.New()
 				return &dag.DAG{
-					Id: uuid.New(),
+					Id:    uuid.New(),
+					Title: "Valid Title",
 					Nodes: map[uuid.UUID]dag.Node{
 						nodeId: {
 							Id:       uuid.New(), // Different ID
@@ -222,7 +235,8 @@ func TestUpdateDAGUseCase_ValidateDAGStructure(t *testing.T) {
 			dag: func() *dag.DAG {
 				nodeId := uuid.New()
 				return &dag.DAG{
-					Id: uuid.New(),
+					Id:    uuid.New(),
+					Title: "Valid Title",
 					Nodes: map[uuid.UUID]dag.Node{
 						nodeId: {
 							Id:       nodeId,
@@ -241,7 +255,8 @@ func TestUpdateDAGUseCase_ValidateDAGStructure(t *testing.T) {
 				nodeId := uuid.New()
 				answerId := uuid.New()
 				return &dag.DAG{
-					Id: uuid.New(),
+					Id:    uuid.New(),
+					Title: "Valid Title",
 					Nodes: map[uuid.UUID]dag.Node{
 						nodeId: {
 							Id:       nodeId,
@@ -266,7 +281,8 @@ func TestUpdateDAGUseCase_ValidateDAGStructure(t *testing.T) {
 				answerId := uuid.New()
 				nonExistentNodeId := uuid.New()
 				return &dag.DAG{
-					Id: uuid.New(),
+					Id:    uuid.New(),
+					Title: "Valid Title",
 					Nodes: map[uuid.UUID]dag.Node{
 						nodeId: {
 							Id:       nodeId,
@@ -342,7 +358,8 @@ func createValidTestDAG() *dag.DAG {
 	answerId2 := uuid.New()
 
 	return &dag.DAG{
-		Id: dagId,
+		Id:    dagId,
+		Title: "Test Legal Case",
 		Nodes: map[uuid.UUID]dag.Node{
 			rootNodeId: {
 				Id:       rootNodeId,


### PR DESCRIPTION
This PR adds a title property to DAGs and ensures it cannot be empty during updates.

Key changes:
- Added Title field to DAG struct with JSON serialization
- Added validation to ensure title cannot be empty during updates  
- Updated DAGPresenter to include title field in API responses
- Updated NewDAG constructor to require title parameter
- Updated all tests and added new validation tests

All tests pass and backward compatibility is maintained.